### PR TITLE
Fixes the URL for sub-uri deployments

### DIFF
--- a/lib/smart_proxy_openscap/openscap_lib.rb
+++ b/lib/smart_proxy_openscap/openscap_lib.rb
@@ -86,7 +86,7 @@ module Proxy::OpenSCAP
 
   def self.fetch_scap_content_xml(policy_id, policy_scap_file)
     foreman_request = Proxy::HttpRequest::ForemanRequest.new
-    policy_content_path = "/api/v2/compliance/policies/#{policy_id}/content"
+    policy_content_path = "api/v2/compliance/policies/#{policy_id}/content"
     req = foreman_request.request_factory.create_get(policy_content_path)
     response = foreman_request.send_request(req)
     unless response.is_a? Net::HTTPSuccess


### PR DESCRIPTION
If foreman runs on sub-uri (e.g. example.com/foreman) which is set as foreman_url in smart proxy, the sub-uri part gets dropped because we specify the path as absolute. For more details why we shouldn't put slash in the beginning, see http://projects.theforeman.org/issues/9740 (and related PR).