### PR TITLE
fixes #10686 - Add path to smart proxy for openscap-send log

### DIFF
--- a/bin/smart-proxy-openscap-send
+++ b/bin/smart-proxy-openscap-send
@@ -23,7 +23,7 @@ exit unless Proxy::OpenSCAP::Plugin.settings.enabled == true
 
 module Proxy
   module Log
-    @@logger = ::Logger.new(Proxy::OpenSCAP::Plugin.settings.openscap_send_log_file, 6, 1024*1024*10)
+    @@logger = ::Logger.new(Proxy::OpenSCAP.fullpath(Proxy::OpenSCAP::Plugin.settings.openscap_send_log_file), 6, 1024*1024*10)
     @@logger.level = ::Logger.const_get(Proxy::SETTINGS.log_level.upcase)
   end
 end


### PR DESCRIPTION
Add the full path, or ```smart-proxy-openscap-send``` will fail to find the log location