### PR TITLE
Fixes #12390 - Arf reports get deleted from Smart Proxy

### DIFF
--- a/lib/smart_proxy_openscap/openscap_api.rb
+++ b/lib/smart_proxy_openscap/openscap_api.rb
@@ -64,6 +64,15 @@ module Proxy::OpenSCAP
       end
     end
 
+    delete "/arf/:id/:cname/:date/:digest" do
+      begin
+        Proxy::OpenSCAP::StorageFS.new(Proxy::OpenSCAP::Plugin.settings.reportsdir, params[:cname], params[:id], params[:date])
+          .delete_arf_file
+      rescue FileNotFound => e
+        log_halt 500, "Could not find requested file, #{e.message}"
+      end
+    end
+
     get "/arf/:id/:cname/:date/:digest/html" do
       begin
         Proxy::OpenSCAP::StorageFS.new(Proxy::OpenSCAP::Plugin.settings.reportsdir, params[:cname], params[:id], params[:date])

--- a/lib/smart_proxy_openscap/storage.rb
+++ b/lib/smart_proxy_openscap/storage.rb
@@ -36,6 +36,10 @@ module Proxy::OpenSCAP
       raise NotImplementedError
     end
 
+    def delete_arf_file
+      raise NotImplementedError
+    end
+
     private
 
     def validate_id(id)

--- a/lib/smart_proxy_openscap/storage_fs.rb
+++ b/lib/smart_proxy_openscap/storage_fs.rb
@@ -26,6 +26,13 @@ module Proxy::OpenSCAP
       arf_object.html.force_encoding('UTF-8')
     end
 
+    def delete_arf_file
+      path = "#{@path_to_dir}/#{@namespace}/#{@cname}/#{@id}"
+      raise FileNotFound, "Can't find path #{path}" if !File.directory?(path) || File.zero?(path)
+      FileUtils.rm_r path
+      {:id => @id, :deleted => true}.to_json
+    end
+
     private
 
     def store_arf(spool_arf_dir, data)

--- a/test/get_report_xml_html_test.rb
+++ b/test/get_report_xml_html_test.rb
@@ -49,4 +49,10 @@ class OpenSCAPGetArfTest < Test::Unit::TestCase
     assert_equal(500, last_response.status, "Error response should be 500")
     assert(last_response.server_error?)
   end
+
+  def test_delete_arf_file
+    delete "/arf/#{@arf_id}/#{@cname}/#{@date}/#{@filename}"
+    assert last_response.ok?
+    refute  File.exists?("#{@results_path}/reports/arf/#{@cname}/#{@arf_id}")
+  end
 end


### PR DESCRIPTION
Deleting the Arf report files - proxy side of things