### PR TITLE
Fix syntax errors from bad line breaks

### DIFF
--- a/lib/smart_proxy_openscap/openscap_api.rb
+++ b/lib/smart_proxy_openscap/openscap_api.rb
@@ -64,7 +64,7 @@ module Proxy::OpenSCAP
       begin
         Proxy::OpenSCAP::StorageFS.new(Proxy::OpenSCAP::Plugin.settings.reportsdir, params[:cname], params[:id], params[:date]).delete_arf_file
       rescue FileNotFound => e
-        log_halt 500, "Could not find requested file, #{e.message}"
+        logger.debug "Could not find requested file, #{e.message} - Assuming deleted"
       end
     end
 

--- a/lib/smart_proxy_openscap/openscap_api.rb
+++ b/lib/smart_proxy_openscap/openscap_api.rb
@@ -37,18 +37,15 @@ module Proxy::OpenSCAP
 
       begin
         post_to_foreman = ForemanForwarder.new.post_arf_report(cn, policy, date, request.body.string)
-        Proxy::OpenSCAP::StorageFS.new(Proxy::OpenSCAP::Plugin.settings.reportsdir, cn, post_to_foreman['id'], date)
-          .store_archive(request.body.string)
+        Proxy::OpenSCAP::StorageFS.new(Proxy::OpenSCAP::Plugin.settings.reportsdir, cn, post_to_foreman['id'], date).store_archive(request.body.string)
       rescue Proxy::OpenSCAP::StoreReportError => e
-        Proxy::OpenSCAP::StorageFS.new(Proxy::OpenSCAP::Plugin.settings.failed_dir, cn, post_to_foreman['id'], date)
-          .store_failed(request.body.string)
+        Proxy::OpenSCAP::StorageFS.new(Proxy::OpenSCAP::Plugin.settings.failed_dir, cn, post_to_foreman['id'], date).store_failed(request.body.string)
         logger.error "Failed to save Report in reports directory (#{Proxy::OpenSCAP::Plugin.settings.reportsdir}). Failed with: #{e.message}.
                       Saving file in #{Proxy::OpenSCAP::Plugin.settings.failed_dir}. Please copy manually to #{Proxy::OpenSCAP::Plugin.settings.reportsdir}"
       rescue *HTTP_ERRORS => e
         ### If the upload to foreman fails then store it in the spooldir
         logger.error "Failed to upload to Foreman, saving in spool. Failed with: #{e.message}"
-        Proxy::OpenSCAP::StorageFS.new(Proxy::OpenSCAP::Plugin.settings.spooldir, cn, policy, date)
-          .store_spool(request.body.string)
+        Proxy::OpenSCAP::StorageFS.new(Proxy::OpenSCAP::Plugin.settings.spooldir, cn, policy, date).store_spool(request.body.string)
       rescue Proxy::OpenSCAP::StoreSpoolError => e
         log_halt 500, e.message
       end
@@ -57,8 +54,7 @@ module Proxy::OpenSCAP
     get "/arf/:id/:cname/:date/:digest/xml" do
       content_type 'application/x-bzip2'
       begin
-        Proxy::OpenSCAP::StorageFS.new(Proxy::OpenSCAP::Plugin.settings.reportsdir, params[:cname], params[:id], params[:date])
-          .get_arf_xml(params[:digest])
+        Proxy::OpenSCAP::StorageFS.new(Proxy::OpenSCAP::Plugin.settings.reportsdir, params[:cname], params[:id], params[:date]).get_arf_xml(params[:digest])
       rescue FileNotFound => e
         log_halt 500, "Could not find requested file, #{e.message}"
       end
@@ -66,17 +62,15 @@ module Proxy::OpenSCAP
 
     delete "/arf/:id/:cname/:date/:digest" do
       begin
-        Proxy::OpenSCAP::StorageFS.new(Proxy::OpenSCAP::Plugin.settings.reportsdir, params[:cname], params[:id], params[:date])
-          .delete_arf_file
+        Proxy::OpenSCAP::StorageFS.new(Proxy::OpenSCAP::Plugin.settings.reportsdir, params[:cname], params[:id], params[:date]).delete_arf_file
       rescue FileNotFound => e
-        logger.debug "Could not find requested file, #{e.message} - Assuming deleted"
+        log_halt 500, "Could not find requested file, #{e.message}"
       end
     end
 
     get "/arf/:id/:cname/:date/:digest/html" do
       begin
-        Proxy::OpenSCAP::StorageFS.new(Proxy::OpenSCAP::Plugin.settings.reportsdir, params[:cname], params[:id], params[:date])
-          .get_arf_html(params[:digest])
+        Proxy::OpenSCAP::StorageFS.new(Proxy::OpenSCAP::Plugin.settings.reportsdir, params[:cname], params[:id], params[:date]).get_arf_html(params[:digest])
       rescue FileNotFound => e
         log_halt 500, "Could not find requested file, #{e.message}"
       end


### PR DESCRIPTION
This pull fixes the following errors received after installing rubygem-smart_proxy_openscap-0.5.3-1.el6.noarch

E, [2016-04-04T20:25:29.991127 #1340] ERROR -- : Error during startup, terminating. /usr/lib/ruby/site_ruby/1.8/rubygems/custom_require.rb:31:in `gem_original_require': /usr/lib/ruby/gems/1.8/gems/smart_proxy_openscap-0.5.3/lib/smart_proxy_openscap/openscap_api.rb:41: syntax error, unexpected '.', expecting kEND
          .store_archive(request.body.string)
           ^
/usr/lib/ruby/gems/1.8/gems/smart_proxy_openscap-0.5.3/lib/smart_proxy_openscap/openscap_api.rb:44: syntax error, unexpected '.', expecting kEND
          .store_failed(request.body.string)
           ^
/usr/lib/ruby/gems/1.8/gems/smart_proxy_openscap-0.5.3/lib/smart_proxy_openscap/openscap_api.rb:51: syntax error, unexpected '.', expecting kEND
          .store_spool(request.body.string)
           ^
/usr/lib/ruby/gems/1.8/gems/smart_proxy_openscap-0.5.3/lib/smart_proxy_openscap/openscap_api.rb:61: syntax error, unexpected '.', expecting kEND
          .get_arf_xml(params[:digest])
           ^
/usr/lib/ruby/gems/1.8/gems/smart_proxy_openscap-0.5.3/lib/smart_proxy_openscap/openscap_api.rb:70: syntax error, unexpected '.', expecting kEND
          .delete_arf_file
           ^
/usr/lib/ruby/gems/1.8/gems/smart_proxy_openscap-0.5.3/lib/smart_proxy_openscap/openscap_api.rb:79: syntax error, unexpected '.', expecting kEND
          .get_arf_html(params[:digest])
           ^
