### PR TITLE
Update openscap_import_api.rb

### DIFF
--- a/lib/smart_proxy_openscap/openscap_import_api.rb
+++ b/lib/smart_proxy_openscap/openscap_import_api.rb
@@ -14,18 +14,15 @@ module Proxy::OpenSCAP
 
       post_to_foreman = ForemanForwarder.new.post_arf_report(cn, policy, date, request.body.string)
       begin
-        Proxy::OpenSCAP::StorageFS.new(Proxy::OpenSCAP::Plugin.settings.reportsdir, cn, post_to_foreman['id'], date)
-          .store_archive(request.body.string)
+        Proxy::OpenSCAP::StorageFS.new(Proxy::OpenSCAP::Plugin.settings.reportsdir, cn, post_to_foreman['id'], date).store_archive(request.body.string)
       rescue Proxy::OpenSCAP::StoreReportError => e
-        Proxy::OpenSCAP::StorageFS.new(Proxy::OpenSCAP::Plugin.settings.failed_dir, cn, post_to_foreman['id'], date)
-          .store_failed(request.body.string)
+        Proxy::OpenSCAP::StorageFS.new(Proxy::OpenSCAP::Plugin.settings.failed_dir, cn, post_to_foreman['id'], date).store_failed(request.body.string)
         logger.error "Failed to save Report in reports directory (#{Proxy::OpenSCAP::Plugin.settings.reportsdir}). Failed with: #{e.message}.
                         Saving file in #{Proxy::OpenSCAP::Plugin.settings.failed_dir}. Please copy manually to #{Proxy::OpenSCAP::Plugin.settings.reportsdir}"
       rescue *HTTP_ERRORS => e
         ### If the upload to foreman fails then store it in the spooldir
         logger.error "Failed to upload to Foreman, saving in spool. Failed with: #{e.message}"
-        Proxy::OpenSCAP::StorageFS.new(Proxy::OpenSCAP::Plugin.settings.spooldir, cn, policy, date)
-          .store_spool(request.body.string)
+        Proxy::OpenSCAP::StorageFS.new(Proxy::OpenSCAP::Plugin.settings.spooldir, cn, policy, date).store_spool(request.body.string)
       rescue Proxy::OpenSCAP::StoreSpoolError => e
         log_halt 500, e.message
       end


### PR DESCRIPTION
Fixing errors:

/usr/lib/ruby/site_ruby/1.8/rubygems/custom_require.rb:31:in `gem_original_require': /usr/lib/ruby/gems/1.8/gems/smart_proxy_openscap-0.5.3/lib/smart_proxy_openscap/openscap_import_api.rb:18: syntax error, unexpected '.', expecting kEND
          .store_archive(request.body.string)
           ^
/usr/lib/ruby/gems/1.8/gems/smart_proxy_openscap-0.5.3/lib/smart_proxy_openscap/openscap_import_api.rb:21: syntax error, unexpected '.', expecting kEND
          .store_failed(request.body.string)
           ^
/usr/lib/ruby/gems/1.8/gems/smart_proxy_openscap-0.5.3/lib/smart_proxy_openscap/openscap_import_api.rb:28: syntax error, unexpected '.', expecting kEND
          .store_spool(request.body.string)
           ^