### PR TITLE
Fixes #18086 - Fix typo in smart-proxy-openscap-send

### DIFF
--- a/bin/smart-proxy-openscap-send
+++ b/bin/smart-proxy-openscap-send
@@ -38,7 +38,7 @@ end
 begin
   Proxy::OpenSCAP::send_spool_to_foreman
 rescue StandardError => e
-  logger.error "#{e}
+  logger.error e
   puts "#{e} See #{Proxy::OpenSCAP.fullpath(Proxy::OpenSCAP::Plugin.settings.openscap_send_log_file)}"
   exit false
 end


### PR DESCRIPTION
:laughing: 
BTW, does anyone know why line 42 has `puts ` and not `logger`?