### PR TITLE
Fixes #18926 - Destroy openscap objects to release memory

### DIFF
--- a/lib/smart_proxy_openscap/foreman_forwarder.rb
+++ b/lib/smart_proxy_openscap/foreman_forwarder.rb
@@ -3,10 +3,10 @@ module Proxy::OpenSCAP
     include ::Proxy::Log
 
     def post_arf_report(cname, policy_id, date, data)
+        parser = Proxy::OpenSCAP::Parse.new(data)
       begin
-        json_data = Proxy::OpenSCAP::Parse.new(data).as_json
         foreman_api_path = upload_path(cname, policy_id, date)
-        response = send_request(foreman_api_path, json_data)
+        response = send_request(foreman_api_path, parser.as_json)
         # Raise an HTTP error if the response is not 2xx (success).
         response.value
         res = JSON.parse(response.body)
@@ -18,6 +18,8 @@ module Proxy::OpenSCAP
         logger.debug response.body if response
         logger.debug e.backtrace.join("\n\t")
         raise e
+      ensure
+        parser.cleanup
       end
       res
     end

--- a/lib/smart_proxy_openscap/openscap_api.rb
+++ b/lib/smart_proxy_openscap/openscap_api.rb
@@ -114,22 +114,28 @@ module Proxy::OpenSCAP
     end
 
     post "/scap_content/policies" do
+      content_parser = create_content_parser
       begin
-        Proxy::OpenSCAP::ContentParser.new(request.body.string).extract_policies
+        content_parser.extract_policies
       rescue *HTTP_ERRORS => e
         log_halt 500, e.message
       rescue StandardError => e
         log_halt 500, "Error occurred: #{e.message}"
+      ensure
+        content_parser.cleanup
       end
     end
 
     post "/tailoring_file/profiles" do
+      content_parser = create_content_parser
       begin
-        Proxy::OpenSCAP::ContentParser.new(request.body.string).get_profiles
+        content_parser.get_profiles
       rescue *HTTP_ERRORS => e
         log_halt 500, e.message
       rescue StandardError => e
         log_halt 500, "Error occurred: #{e.message}"
+      ensure
+        content_parser.cleanup
       end
     end
 
@@ -144,12 +150,15 @@ module Proxy::OpenSCAP
     end
 
     post "/scap_content/guide/:policy" do
+      content_parser = create_content_parser
       begin
-        Proxy::OpenSCAP::ContentParser.new(request.body.string).guide(params[:policy])
+        content_parser.guide(params[:policy])
       rescue *HTTP_ERRORS => e
         log_halt 500, e.message
       rescue StandardError => e
         log_halt 500, "Error occurred: #{e.message}"
+      ensure
+        content_parser.cleanup
       end
     end
 
@@ -163,6 +172,10 @@ module Proxy::OpenSCAP
       rescue StandardError => e
         log_halt 500, "Error occurred: #{e.message}"
       end
+    end
+
+    def create_content_parser
+      Proxy::OpenSCAP::ContentParser.new(request.body.string)
     end
   end
 end

--- a/lib/smart_proxy_openscap/openscap_content_parser.rb
+++ b/lib/smart_proxy_openscap/openscap_content_parser.rb
@@ -11,6 +11,11 @@ module Proxy::OpenSCAP
       @type = type
     end
 
+    def cleanup
+      @source.destroy if @source
+      OpenSCAP.oscap_cleanup
+    end
+
     def allowed_types
       {
         'tailoring_file' => 'XCCDF Tailoring',

--- a/lib/smart_proxy_openscap/openscap_report_parser.rb
+++ b/lib/smart_proxy_openscap/openscap_report_parser.rb
@@ -16,11 +16,21 @@ module Proxy::OpenSCAP
       size         = arf_data.size
       @arf_digest  = Digest::SHA256.hexdigest(arf_data)
       @arf         = OpenSCAP::DS::Arf.new(:content => arf_data, :path => 'arf.xml.bz2', :length => size)
-      @results     = @arf.test_result.rr
-      sds          = @arf.report_request
-      bench_source = sds.select_checklist!
-      @bench       = OpenSCAP::Xccdf::Benchmark.new(bench_source)
-      @items       = @bench.items
+      @test_result  = @arf.test_result
+
+      @results      = @test_result.rr
+      @sds          = @arf.report_request
+      bench_source = @sds.select_checklist!
+      @benchmark    = OpenSCAP::Xccdf::Benchmark.new(bench_source)
+      @items        = @benchmark.items
+    end
+
+    def cleanup
+      @test_result.destroy if @test_result
+      @benchmark.destroy if @benchmark
+      @sds.destroy if @sds
+      @arf.destroy if @arf
+      OpenSCAP.oscap_cleanup
     end
 
     def as_json


### PR DESCRIPTION
I found out that devel proxy will increase memory usage even if you make request to /features many times. I generated and parsed 10000 reports in production with this and memory usage for proxy changed from 0.0% to 0.1%, so it seems to take care of the issue. 