### PR TITLE
Fixes #21164 - add missing ensure blocks

### DIFF
--- a/lib/smart_proxy_openscap/arf_html.rb
+++ b/lib/smart_proxy_openscap/arf_html.rb
@@ -7,6 +7,7 @@ module Proxy
       def generate_html(file_in, file_out)
         ::OpenSCAP.oscap_init
         File.write file_out, get_arf_html(file_in)
+      ensure
         ::OpenSCAP.oscap_cleanup
       end
 

--- a/lib/smart_proxy_openscap/policy_guide.rb
+++ b/lib/smart_proxy_openscap/policy_guide.rb
@@ -14,8 +14,9 @@ module Proxy
         profile_id = policy ? nil : policy
         html = sds.html_guide profile_id
         File.write(out_file, { :html => html.force_encoding('UTF-8') }.to_json)
-        sds.destroy
-        source.destroy
+      ensure
+        sds.destroy if sds
+        source.destroy if source
         ::OpenSCAP.oscap_cleanup
       end
     end

--- a/lib/smart_proxy_openscap/scap_profiles.rb
+++ b/lib/smart_proxy_openscap/scap_profiles.rb
@@ -13,22 +13,25 @@ module Proxy
         source = ::OpenSCAP::Source.new(in_file)
         json = type == 'scap_content' ? scap_content_profiles(source) : tailoring_profiles(source)
         File.write out_file, json
-        source.destroy
+      ensure
+        source.destroy if source
         ::OpenSCAP.oscap_cleanup
       end
 
       def scap_content_profiles(source)
         bench = benchmark_profiles source
         profiles = collect_profiles bench
-        bench.destroy
         profiles.to_json
+      ensure
+        bench.destroy if bench
       end
 
       def tailoring_profiles(source)
         tailoring = ::OpenSCAP::Xccdf::Tailoring.new(source, nil)
         profiles = collect_profiles tailoring
-        tailoring.destroy
         profiles.to_json
+      ensure
+        tailoring.destroy if tailoring
       end
 
       def collect_profiles(profile_source)
@@ -41,8 +44,8 @@ module Proxy
         sds          = ::OpenSCAP::DS::Sds.new(source)
         bench_source = sds.select_checklist!
         benchmark = ::OpenSCAP::Xccdf::Benchmark.new(bench_source)
-        sds.destroy
-        benchmark
+      ensure
+        sds.destroy if sds
       end
     end
   end

--- a/lib/smart_proxy_openscap/scap_validation.rb
+++ b/lib/smart_proxy_openscap/scap_validation.rb
@@ -26,7 +26,8 @@ module Proxy
           errors << "Invalid SCAP file type"
         end
         File.write out_file, { :errors => errors }.to_json
-        source.destroy
+      ensure
+        source.destroy if source
         ::OpenSCAP.oscap_cleanup
       end
     end


### PR DESCRIPTION
I have no proofs this fixes any memory leaks at all, but it is a good practice to add those ensure blocks. I have a suspicion that it might help my customer to mitigate memory leaks in Satellite 6.2 branch.