### PR TITLE
Fixes #22511 - Load settings when sending from spool

### DIFF
--- a/bin/smart-proxy-openscap-send
+++ b/bin/smart-proxy-openscap-send
@@ -17,14 +17,16 @@ require 'smart_proxy_main'
 require 'smart_proxy_openscap'
 require 'smart_proxy_openscap/openscap_lib'
 
-# Don't run if OpenSCAP plugin is disabled.
-exit unless Proxy::OpenSCAP::Plugin.settings.enabled == true
+loaded_settings = Proxy::OpenSCAP.plugin_settings
 
-# TODO: include some jitter to not bring Foreman to its knees
+# Don't run if OpenSCAP plugin is disabled or settings are missing.
+if !loaded_settings.enabled || loaded_settings.nil? || loaded_settings.empty?
+  exit 436
+end
 
 module Proxy
   module Log
-    @@logger = ::Logger.new(Proxy::OpenSCAP.fullpath(Proxy::OpenSCAP::Plugin.settings.openscap_send_log_file), 6, 1024*1024*10)
+    @@logger = ::Logger.new(Proxy::OpenSCAP.fullpath(Proxy::OpenSCAP.plugin_settings.openscap_send_log_file), 6, 1024*1024*10)
     @@logger.level = ::Logger.const_get(Proxy::SETTINGS.log_level.upcase)
   end
 end
@@ -32,13 +34,13 @@ include Proxy::Log
 
 if !Proxy::SETTINGS.foreman_url
   logger.error "Foreman URL not configured"
-  exit false
+  exit 437
 end
 
 begin
-  Proxy::OpenSCAP::send_spool_to_foreman
+  Proxy::OpenSCAP::send_spool_to_foreman(loaded_settings)
 rescue StandardError => e
   logger.error e
-  puts "#{e} See #{Proxy::OpenSCAP.fullpath(Proxy::OpenSCAP::Plugin.settings.openscap_send_log_file)}"
-  exit false
+  puts "#{e} See #{Proxy::OpenSCAP.fullpath(loaded_settings.openscap_send_log_file)}"
+  exit 438
 end

--- a/lib/smart_proxy_openscap/spool_forwarder.rb
+++ b/lib/smart_proxy_openscap/spool_forwarder.rb
@@ -2,6 +2,10 @@ module Proxy::OpenSCAP
   class SpoolForwarder
     include ::Proxy::Log
 
+    def initialize(loaded_settings)
+      @loaded_settings = loaded_settings
+    end
+
     def post_arf_from_spool(arf_dir)
       Dir.foreach(arf_dir) do |cname|
         next if cname == '.' || cname == '..'
@@ -49,12 +53,12 @@ module Proxy::OpenSCAP
     def forward_arf_file(cname, policy_id, date, arf_file_path)
       data = File.open(arf_file_path, 'rb') { |io| io.read }
       post_to_foreman = ForemanForwarder.new.post_arf_report(cname, policy_id, date, data)
-      Proxy::OpenSCAP::StorageFS.new(Proxy::OpenSCAP::Plugin.settings.reportsdir, cname, post_to_foreman['id'], date).store_archive(data)
+      Proxy::OpenSCAP::StorageFS.new(@loaded_settings.reportsdir, cname, post_to_foreman['id'], date).store_archive(data)
       File.delete arf_file_path
     rescue Proxy::OpenSCAP::OpenSCAPException => e
-      logger.error "Failed to parse Arf Report at #{arf_file_path}, moving to #{Proxy::OpenSCAP::Plugin.settings.corrupted_dir}"
+      logger.error "Failed to parse Arf Report at #{arf_file_path}, moving to #{@loaded_settings.corrupted_dir}"
 
-      Proxy::OpenSCAP::StorageFS.new(Proxy::OpenSCAP::Plugin.settings.corrupted_dir, cname, policy_id, date).
+      Proxy::OpenSCAP::StorageFS.new(@loaded_settings.corrupted_dir, cname, policy_id, date).
         move_corrupted(arf_file_path.split('/').last)
 
     rescue StandardError => e


### PR DESCRIPTION
Simply calling `settings` on our plugin does not work any more, we need to initialize plugins to get the settings loaded. Unfortunately, we get the initializing info printed to the logs:

![](https://i.imgur.com/AIL134z.png)

@witlessbird, is there a better way to do this?