### PR TITLE
fixes #30576 - Do not use scl if not avaiable

### DIFF
--- a/bin/smart-proxy-openscap-send
+++ b/bin/smart-proxy-openscap-send
@@ -1,3 +1,7 @@
 #!/bin/bash
 
-scl enable tfm smart-proxy-openscap-send-inner
+if command -v scl &>/dev/null;then
+  scl enable tfm smart-proxy-openscap-send-inner
+else
+  smart-proxy-openscap-send-inner
+fi


### PR DESCRIPTION
On CentOS/RHEL 8 Foreman and the Smart Proxy does not run using SCL so the command `smart-proxy-openscap-send` fails. This is an easy fix by checking for the command `scl` which could perhaps be improved.