### PR TITLE
Fixes #17935 - Remove endpoint for scap_content download

### DIFF
--- a/lib/smart_proxy_openscap/openscap_api.rb
+++ b/lib/smart_proxy_openscap/openscap_api.rb
@@ -101,18 +101,6 @@ module Proxy::OpenSCAP
       end
     end
 
-    get "/policies/:policy_id/content" do
-      content_type 'application/xml'
-      logger.warn 'DEPRECATION WARNING: /policies/:policy_id/content/:digest should be used, please update foreman_openscap'
-      begin
-        Proxy::OpenSCAP::FetchScapContent.new.get_policy_content(params[:policy_id], 'scap_content')
-      rescue *HTTP_ERRORS => e
-        log_halt e.response.code.to_i, "File not found on Foreman. Wrong policy id?"
-      rescue StandardError => e
-        log_halt 500, "Error occurred: #{e.message}"
-      end
-    end
-
     get "/policies/:policy_id/tailoring/:digest" do
       content_type 'application/xml'
       begin


### PR DESCRIPTION
This has been deprecated for ages, I think we should remove it at some point.