### PR TITLE
Fixes #32257 - use trusted hosts to authorize clients

### DIFF
--- a/lib/smart_proxy_openscap/openscap_api.rb
+++ b/lib/smart_proxy_openscap/openscap_api.rb
@@ -25,6 +25,13 @@ module Proxy::OpenSCAP
     include ::Proxy::Log
     helpers ::Proxy::Helpers
     authorize_with_ssl_client
+    CLIENT_PATHS = Regexp.compile(%r{^(/arf/\d+|/policies/\d+/content/|/policies/\d+/tailoring/)})
+
+    # authorize via trusted hosts but let client paths in without such authorization
+    before do
+      pass if request.path_info =~ CLIENT_PATHS
+      do_authorize_with_trusted_hosts
+    end
 
     post "/arf/:policy" do
       # first let's verify client's certificate


### PR DESCRIPTION
An improper authorization handling flaw was found in Foreman. The OpenSCAP plugin for the smart-proxy allows foreman clients to execute actions that should be limited to the Foreman Server. This flaw allows an authenticated local attacker to access and delete limited resources and also causes a denial of service on the Foreman server. The highest threat from this vulnerability is to integrity and system availability.

https://access.redhat.com/security/cve/CVE-2021-20290