### PR TITLE
Fixes #34554 - remove the improper validation

### DIFF
--- a/lib/smart_proxy_openscap/content_parser.rb
+++ b/lib/smart_proxy_openscap/content_parser.rb
@@ -3,8 +3,10 @@ require 'openscap_parser/tailoring_file'
 
 module Proxy::OpenSCAP
   class ContentParser
+    include ::Proxy::Log
+
     def validate(file_type, scap_file)
-      msg = 'Invalid SCAP file type'
+      msg = 'Invalid XML format'
       errors = []
       file = nil
       begin
@@ -14,8 +16,9 @@ module Proxy::OpenSCAP
         when 'tailoring_file'
           file = ::OpenscapParser::TailoringFile.new(scap_file)
         end
-        errors << msg unless file.valid?
       rescue Nokogiri::XML::SyntaxError => e
+        logger.error msg
+        logger.error e.backtrace.join("\n")
         errors << msg
       end
       { errors: errors }


### PR DESCRIPTION
During the transition to the openscap_parser gem to avoid using the
ffi wrappers around the C library, a trivial validation was introduced.
Such validation turned to be very limited and not supporting non-RH
valid SCAP content. This patch removes the validation. The only proper
solution would be to shell out to the oscap tool, but the purpose was to
be independent of it.