### PR TITLE
Fixes #37554 - Fork before parsing report XML

### DIFF
--- a/lib/smart_proxy_openscap/helpers.rb
+++ b/lib/smart_proxy_openscap/helpers.rb
@@ -1,0 +1,26 @@
+# lib/helpers.rb
+
+module Proxy::OpenSCAP
+  module Helpers
+    def forked_response
+      r, w = IO.pipe
+      if child_id = Process.fork
+        w.close
+        data = r.read
+        r.close
+        Process.wait(child_id)
+        JSON.parse(data)
+      else
+        r.close
+        begin
+          body, code = yield
+          w.write({ code: code, body: body }.to_json)
+        rescue Exception => e
+          w.write({ code: 500, body: e.message }.to_json)
+        end
+        w.close
+        Process.exit!
+      end
+    end
+  end
+end

--- a/lib/smart_proxy_openscap/helpers.rb
+++ b/lib/smart_proxy_openscap/helpers.rb
@@ -2,24 +2,31 @@
 
 module Proxy::OpenSCAP
   module Helpers
-    def forked_response
-      r, w = IO.pipe
-      if child_id = Process.fork
-        w.close
-        data = r.read
-        r.close
-        Process.wait(child_id)
-        JSON.parse(data)
-      else
-        r.close
-        begin
-          body, code = yield
-          w.write({ code: code, body: body }.to_json)
-        rescue Exception => e
-          w.write({ code: 500, body: e.message }.to_json)
+    if Process.respond_to?(:fork)
+      def forked_response
+        r, w = IO.pipe
+        if child_id = Process.fork
+          w.close
+          data = r.read
+          r.close
+          Process.wait(child_id)
+          JSON.parse(data)
+        else
+          r.close
+          begin
+            body, code = yield
+            w.write({ code: code, body: body }.to_json)
+          rescue Exception => e
+            w.write({ code: 500, body: e.message }.to_json)
+          end
+          w.close
+          Process.exit!
         end
-        w.close
-        Process.exit!
+      end
+    else
+      def forked_response
+        body, code = yield
+        { code: code, body: body }
       end
     end
   end


### PR DESCRIPTION
Parsing of report XMLs seems to be the biggest thing that makes memory consupmtion skyrocket. This change attempts to mitigate that by forking off a child process, inside which the parsing happens. Once the parsing is done, the child process exits and the additional memory it accumulated gets released. The parsed report is sent back to the parent process through a pipe.

The error handling is slightly iffy here, if the child exits with non-zero exit code, we assume that an exception was raised in it and either try to reconstruct the original exception from the data we get from the child or just raise a general exception.

When foreman-proxy starts it seems to take ~70MB. I then proceeded to upload five reports and checked the memory consupmtion again. Without this patch, it went to ~1.3GB, with this patch it went up to only 134MB.