### PR TITLE
Support bundler < 2.3 again

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -6,7 +6,7 @@ group :development do
   gem 'pry'
   gem 'pry-byebug'
   gem 'rubocop'
-  gem 'smart_proxy', :github => "theforeman/smart-proxy", :branch => ENV['SMART_PROXY_BRANCH']
+  gem 'smart_proxy', :github => "theforeman/smart-proxy", :branch => ENV.fetch('SMART_PROXY_BRANCH', 'develop')
 end
 
 # load local gemfile


### PR DESCRIPTION
Bundler 2.3 has learned to deal with git repos that name their branch something other than develop, but only Ruby 3.1 started to ship that version.

Fixes: cab14f214676 ("Respect SMART_PROXY_BRANCH for better CI support")