### PR TITLE
Fixes #38224 - Make reports available after upload timeout

### DIFF
--- a/lib/smart_proxy_openscap/arf_html.rb
+++ b/lib/smart_proxy_openscap/arf_html.rb
@@ -7,7 +7,7 @@ module Proxy
       include ::Proxy::Log
 
       def generate(cname, id, date, digest)
-        file_path = file_path_in_storage cname, id, date, digest
+        file_path = file_path_in_storage(cname, id, date, digest)
         as_html file_path
       end
 


### PR DESCRIPTION
Currently, when the OpenSCAP scan report is not uploaded to Foreman after the scan finishes because it times out, the report is saved in /var/spool on the proxy. When the report is requested from foreman, it cannot be found because it is not being searched for in spool.

This PR aims to fix this by searching for the report in the spooldir and moving it to the proper storage place.